### PR TITLE
update to newer tasmota version

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -53,11 +53,15 @@ class TasmotaCollector(object):
                 label = string_values[i].split("{m}")[0]
                 value = string_values[i].split("{m}")[1].split("{e}")[0]
                 if "<td" in value:
-                    value = value.replace("</td><td style='text-align:left'>", "").split("</td>")[0]
+                    value = value.replace("</td><td style='text-align:left'>", "")
+                    value = value.replace("</td><td>&nbsp;</td><td>", "")
 
                 values[label] = value
             except IndexError:
+                print("Index Error")
                 continue
+            print(label)
+            print(value)
         return values
 
 def signal_handler(signal, frame):

--- a/metrics.py
+++ b/metrics.py
@@ -58,10 +58,7 @@ class TasmotaCollector(object):
 
                 values[label] = value
             except IndexError:
-                print("Index Error")
                 continue
-            print(label)
-            print(value)
         return values
 
 def signal_handler(signal, frame):

--- a/metrics.py
+++ b/metrics.py
@@ -57,10 +57,7 @@ class TasmotaCollector(object):
 
                 values[label] = value
             except IndexError:
-                print("Index Error")
                 continue
-            print(label)
-            print(value)
         return values
 
 def signal_handler(signal, frame):

--- a/metrics.py
+++ b/metrics.py
@@ -49,10 +49,18 @@ class TasmotaCollector(object):
 
         string_values = str(page.text).split("{s}")
         for i in range(1,len(string_values)):
-            label = string_values[i].split("{m}")[0]
-            value = string_values[i].split("{m}")[1].split("{e}")[0]
-            values[label] = value
+            try:
+                label = string_values[i].split("{m}")[0]
+                value = string_values[i].split("{m}")[1].split("{e}")[0]
+                if "<td" in value:
+                    value = value.replace("</td><td style='text-align:left'>", "").split("</td>")[0]
 
+                values[label] = value
+            except IndexError:
+                print("Index Error")
+                continue
+            print(label)
+            print(value)
         return values
 
 def signal_handler(signal, frame):


### PR DESCRIPTION
Hey there,
newer Version of tasmota smart plugs have a different output.
The old output:
```
{t}{s}Voltage{m}236 V{e}{s}Current{m}0.287 A{e}{s}Power{m}57 W{e}{s}Apparent Power{m}68 VA{e}{s}Reactive Power{m}37 VAr{e}{s}Power Factor{m}0.84{e}{s}Energy Today{m}0.534 kWh{e}{s}Energy Yesterday{m}1.406 kWh{e}{s}Energy Total{m}564.127 kWh{e}</table>{t}<tr><td style='width:100{c}bold;font-size:62px'>ON</div></td></tr></table>
```
The new output:
```
{t}</table><hr/>{t}{s}</th><th></th><th style='text-align:center'><th></th><td>{e}{s}Voltage{m}</td><td style='text-align:left'>237</td><td>&nbsp;</td><td> V{e}{s}Current{m}</td><td style='text-align:left'>0.039</td><td>&nbsp;</td><td> A{e}{s}Active Power{m}</td><td style='text-align:left'> 2</td><td>&nbsp;</td><td> W{e}{s}Apparent Power{m}</td><td style='text-align:left'> 9</td><td>&nbsp;</td><td> VA{e}{s}Reactive Power{m}</td><td style='text-align:left'> 9</td><td>&nbsp;</td><td> VAr{e}{s}Power Factor{m}</td><td style='text-align:left'>0.21</td><td>&nbsp;</td><td>{e}{s}Energy Today{m}</td><td style='text-align:left'>0.017</td><td>&nbsp;</td><td> kWh{e}{s}Energy Yesterday{m}</td><td style='text-align:left'>0.738</td><td>&nbsp;</td><td> kWh{e}{s}Energy Total{m}</td><td style='text-align:left'>17.144</td><td>&nbsp;</td><td> kWh{e}</table><hr/>{t}</table>{t}<tr><td style='width:100%;text-align:center;font-weight:bold;font-size:62px'>ON</td></tr><tr></tr></table>

```

Therefor the parser was running in an index error.
I firstly checked the index error to keep the program running.
Then i refined the parsing for the new table structure.

PS: we could do the parsing better, but it works :)

Best regards,
LarsTi
